### PR TITLE
add sample docs to setup readthedocs

### DIFF
--- a/docs/DevelopmentSetup/git_and_github_guide.rst
+++ b/docs/DevelopmentSetup/git_and_github_guide.rst
@@ -1,0 +1,129 @@
+.. _DevelopmentSetup:
+
+Git and Github guide
+####################
+
+This guide is to help new contributors setup git, github and navigate their way through making contributions to moja global repositories.
+It covers the entire process of contributing right from installing git to opening pull requests.
+
+Setup this project using Git
+----------------------------
+
+Before setting up this project using Git make sure you have installed and configured git by following the instructions `here <https://support.atlassian.com/bitbucket-cloud/docs/install-and-set-up-git/>`_.
+
+
+Fork and Clone this project
+----------------------------
+
+* In your browser, visit https://github.com/moja-global/FLINT. In the upper left corner, there is a **Fork** button. Please click on it to create a fork/copy of the repository on your profile.
+* In the terminal screen, clone this repo by running the command where ``your-username`` represents your Github username.
+::
+
+    git clone https://github.com/<your-username>/FLINT/
+
+* Enter into the newly created project folder by running the command
+::
+
+    cd FLINT
+
+* Configure upstream for the fork so that git can sync work from the upstream if it is updated by running the command
+::
+
+    git remote add upstream https://github.com/moja-global/FLINT/
+
+* Check if upstream is configured by running the command and check if upstream is shown or not.
+::
+
+    git remote -v
+
+* Now, the project is setup using Git. Please carry on with instructions on how to set this up on `Windows <windows_installation.html>`_ or `Linux <docker_installation.html>`_ here. You can revisit this section when you are ready to make a contribution.
+
+Claim an issue
+--------------
+
+This section will demonstrate how to claim an issue to work on using botmojaglobal.
+
+To work on an issue, claim it by adding a comment with ``@botmojaglobal claim`` to the issue thread. botmojaglobal is a GitHub workflow bot forked from the `zulipbot <https://github.com/zulip/zulipbot/>`_; it will assign you to the issue and label the issue as ``in progress``. Some additional notes:
+
+* You can only claim issues with the ``Good for newcomers`` or ``Help Wanted`` labels. botmojaglobal will give you an error if you try to claim an issue without one of those labels.
+
+* Please feel free to ask questions on how to approach the issue or if the tests are failing. The maintainers/reviewers will try to get back to you as soon as possible. You can reach us on the moja-global `slack <https://mojaglobal.slack.com>`_, or through Github.
+
+* If your pull request has some requested changes, after working on it don't forget to leave a comment asking for a review since the reviewers aren't notified when a pull request is updated.
+
+Make a contribution
+-------------------
+
+This section will show you step-by-step how to make a contribution to FLINT using git.
+
+* FLINT stable branch is **develop**. Releases are scheduled periodically when codebase is production-ready and develop is merged into master.
+  develop branch is the latest updated branch and should be used as a base branch for development. All pull requests should be against develop branch only.
+  Make sure you are in the project directory and checkout to develop branch with this command.
+::
+
+    git checkout develop
+
+* Choose an issue to work on. We have issues specifically labelled ``Good for newcomers`` and ``Help Wanted`` for new contributors to claim. Before starting to work on any issue, make sure you have claimed it.
+* Create a new feature branch from develop branch to work on. The feature branch should have a short name that is relevant to the issue that you will be working on. For example, if you are working on improving documentation in the readme for adding a badge, the branch can be name ``add_badge_readme``.
+::
+
+    git checkout -b <feature-branch-name>
+
+* Work on the task. Add tests and documentation for your changes if required. When you are done with your changes, you can check all the files changes using the following command.
+::
+
+    git status
+
+* Add the relevant files and commit the changes. Please make sure that only those files required for this contribution are added. You can later modify your pull request to add other files as per your requirement.
+::
+
+  git add <file> <file> ...
+
+* While committing the changes, make sure your commit message follows our commit-message guidelines mentioned here.
+::
+
+  git commit -m "relevant commit message"
+
+* Make sure your fork is in sync with the latest changes of develop. For this rebase your branch against the latest develop by following the commands below.
+::
+
+    git checkout develop
+    git pull origin develop
+    git checkout <your-branch-name>
+    git rebase develop
+
+* Incase there are any merge conflicts on running the rebase command, follow this guide to resolve them.
+* You can now push your changes onto your feature branch using the command below.
+::
+
+  git push origin <your-branch-name>
+
+
+Create a pull request for your contribution
+-------------------------------------------
+
+You can now create a pull request to get your changes merged into the upstream develop branch. Follow this step-by-step guide to create a pull request on Github.
+
+* Navigate to the pull requests tab under FLINT. Click on the **New pull request** button. Compare your feature branch against the **develop** branch to create the pull request. Fill the pull request template by linking the issue number solved.
+* Incase your pull request is a work in progress, don't forget to add "WIP" in the title of your pull request to let the maintainers know that the pull request is not ready for review yet.
+* Please be patient, someone from our team will review your pull request shortly and provide feedback. Incase there are changes requested, you can follow the section below on how to update/modify your pull request.
+* Also make sure that your pull request is in sync with the latest develop at all times.
+
+NOTE: Don't forget to get credits for your contributions once it gets merged by following this guide `here <contributing/index>`_.
+
+Modify your pull request
+------------------------
+
+Incase your pull request needs further changes, you can update your pull request by following the steps below.
+
+* Checkout on your feature branch of the pull request.
+* Add the changes as required and commit using the amend flag. This will update the last commit thus keeping the commit history clean and within a single commit.
+::
+
+    git add <file1> <file2>
+    git commit -amend
+
+* Push this onto your feature branch but this time with force flag. This will update the pull request automatically. The reviewer won't be notified about this updation, so leave a comment in your pull request if you want a review.
+::
+
+  git push origin <your-branch-name> --force

--- a/docs/DevelopmentSetup/index.rst
+++ b/docs/DevelopmentSetup/index.rst
@@ -1,0 +1,21 @@
+.. _DevelopmentSetup:
+
+FLINT Development Setup
+#######################
+
+This section guides first-time contributors through installing FLINT development environment on Windows and Ubuntu.
+
+The recommended method for installing the FLINT development environment is on Windows using cmake, vcpkg and Visual Studio 2017 or 2019. Inorder to setup FLINT on Linux based systems, Docker containers are preferred. This method creates containers which are a simple way to build FLINT and all required dependencies.
+
+**Before Setting Up FLINT**
+
+- Please make sure that all the prerequisites required have been installed and configured correctly.
+- The repository has been forked and cloned following the Git and Github guide `here <git_and_github_guide.html>`_ .
+- It is highly recommended to first setup the FLINT.example repository to get an overview of how FLINT works since the software might seem a bit complex at first sight. The instructions for setting up FLINT.example repository can be found `here <FLINT.example_installation.html>`_.
+
+Contents:
+
+.. toctree::
+  :maxdepth: 1
+
+  git_and_github_guide

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,56 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'FLINT.Reporting Technical Guide'
+copyright = '2020, Anthony Kwaje'
+author = 'Anthony Kwaje'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = ['recommonmark',
+'sphinx_rtd_theme',
+'sphinx_copybutton',
+]
+
+master_doc = 'index'
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = "sphinx_rtd_theme"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,20 @@
+Moja global Developer Documentation
+===================================
+
+moja global provides tools for estimating emissions and removals of greenhouse gases from the land sector.
+
+FLINT: the Full Lands INtegration Tool
+The Full Lands Integration Tool (FLINT) is the flagship software developed by the moja global community. It is an integrating platform for estimating land-based greenhouse gas emissions and removals. Integrating refers to FLINT’s design to combine a wide range of data with models to achieve more accurate estimates of stocks and fluxes of greenhouse gases. FLINT is consistent with the UNFCCC guidelines.
+
+This Documentation is meant for Developers wishing to contribute to moja global repositories. If you would like to get in touch with the maintainers for other reasons, please drop a mail at info@moja-global.com.
+
+
+.. toctree::
+   :hidden:
+
+   prerequisites/index
+   DevelopmentSetup/index
+   contributing/index
+   DeveloperWorkflow/index
+   faq
+   contact

--- a/docs/prerequisites/git.rst
+++ b/docs/prerequisites/git.rst
@@ -1,0 +1,15 @@
+.. _prerequisites:
+
+Setup Git
+#########
+
+If you already have a Git client and Github account, please skip this section. Otherwise keep on reading!
+
+Install and Configure Git
+-------------------------
+
+To install Git, please refer to the official git installation instructions `here <https://git-scm.com/book/en/v2/Getting-Started-Installing-Git>`_ and the configuration recommendations `here <https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup>`_.
+
+You can sign up for a Github account `here <https://github.com/join>`_.
+
+After successful installation of Git and GitHub account registration, you can proceed with further instructions on how to fork/clone the moja-global repositories `here <../DevelopmentSetup/git_and_github_guide>`_ .

--- a/docs/prerequisites/index.rst
+++ b/docs/prerequisites/index.rst
@@ -1,0 +1,17 @@
+.. _prerequisites:
+
+FLINT Prerequisites
+###################
+
+Before we take a leap into the process of development, please take a moment to verify if you have the necessary tools setup and skills to get started on this project.
+You should be familiar with the following :-
+
+For Windows Based systems
+-------------------------
+
+Contents:
+
+.. toctree::
+  :maxdepth: 2
+
+  git

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+sphinx_copybutton==0.3.1


### PR DESCRIPTION
# Pull Request Template

## Description

Setting up sample docs and readthedocs project setup. These files are a clone of the current readthedocs and can be edited to suit the current flint.reporting docs. The idea of merging this is to quickly provide an example docs for editing directly in. Also this would enable us to set up the subproject route architecture and link the documentation to the main docs in the following format - 
https://moja-global-documentation.readthedocs.io/projects/flintreporting/en/latest/ 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
