### PR TITLE
Change the image adoptopenjdk to eclipse-temurin

### DIFF
--- a/code/services/accountabilities/Dockerfile
+++ b/code/services/accountabilities/Dockerfile
@@ -1,11 +1,11 @@
 # See: https://www.baeldung.com/spring-boot-docker-images
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM eclipse-temurin:17.0.1_12-jre-alpine as builder
 MAINTAINER Anthony Kwaje <kwajeanthony@gmail.com>
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17.0.1_12-jre-alpine
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/code/services/accountability-rules/Dockerfile
+++ b/code/services/accountability-rules/Dockerfile
@@ -1,11 +1,11 @@
 # See: https://www.baeldung.com/spring-boot-docker-images
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM eclipse-temurin:17.0.1_12-jre-alpine as builder
 MAINTAINER Anthony Kwaje <kwajeanthony@gmail.com>
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17.0.1_12-jre-alpine
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/code/services/accountability-types/Dockerfile
+++ b/code/services/accountability-types/Dockerfile
@@ -1,11 +1,11 @@
 # See: https://www.baeldung.com/spring-boot-docker-images
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM eclipse-temurin:17.0.1_12-jre-alpine as builder
 MAINTAINER Anthony Kwaje <kwajeanthony@gmail.com>
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17.0.1_12-jre-alpine
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/code/services/conversion-and-remaining-periods/Dockerfile
+++ b/code/services/conversion-and-remaining-periods/Dockerfile
@@ -1,11 +1,11 @@
 # See: https://www.baeldung.com/spring-boot-docker-images
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM eclipse-temurin:17.0.1_12-jre-alpine as builder
 MAINTAINER Anthony Kwaje <kwajeanthony@gmail.com>
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17.0.1_12-jre-alpine
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/code/services/cover-types/Dockerfile
+++ b/code/services/cover-types/Dockerfile
@@ -1,11 +1,11 @@
 # See: https://www.baeldung.com/spring-boot-docker-images
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM eclipse-temurin:17.0.1_12-jre-alpine as builder
 MAINTAINER Anthony Kwaje <kwajeanthony@gmail.com>
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17.0.1_12-jre-alpine
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/code/services/crf-tables/Dockerfile
+++ b/code/services/crf-tables/Dockerfile
@@ -1,11 +1,11 @@
 # See: https://www.baeldung.com/spring-boot-docker-images
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM eclipse-temurin:17.0.1_12-jre-alpine as builder
 MAINTAINER Anthony Kwaje <kwajeanthony@gmail.com>
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17.0.1_12-jre-alpine
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/code/services/data-aggregator/Dockerfile
+++ b/code/services/data-aggregator/Dockerfile
@@ -1,11 +1,11 @@
 # See: https://www.baeldung.com/spring-boot-docker-images
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM eclipse-temurin:17.0.1_12-jre-alpine as builder
 MAINTAINER Anthony Kwaje <kwajeanthony@gmail.com>
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17.0.1_12-jre-alpine
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/code/services/data-processor/Dockerfile
+++ b/code/services/data-processor/Dockerfile
@@ -1,11 +1,11 @@
 # See: https://www.baeldung.com/spring-boot-docker-images
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM eclipse-temurin:17.0.1_12-jre-alpine as builder
 MAINTAINER Anthony Kwaje <kwajeanthony@gmail.com>
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17.0.1_12-jre-alpine
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/code/services/databases/Dockerfile
+++ b/code/services/databases/Dockerfile
@@ -1,11 +1,11 @@
 # See: https://www.baeldung.com/spring-boot-docker-images
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM eclipse-temurin:17.0.1_12-jre-alpine as builder
 MAINTAINER Anthony Kwaje <kwajeanthony@gmail.com>
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17.0.1_12-jre-alpine
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/code/services/dates/Dockerfile
+++ b/code/services/dates/Dockerfile
@@ -1,11 +1,11 @@
 # See: https://www.baeldung.com/spring-boot-docker-images
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM eclipse-temurin:17.0.1_12-jre-alpine as builder
 MAINTAINER Anthony Kwaje <kwajeanthony@gmail.com>
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17.0.1_12-jre-alpine
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/code/services/emission-types/Dockerfile
+++ b/code/services/emission-types/Dockerfile
@@ -1,11 +1,11 @@
 # See: https://www.baeldung.com/spring-boot-docker-images
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM eclipse-temurin:17.0.1_12-jre-alpine as builder
 MAINTAINER Anthony Kwaje <kwajeanthony@gmail.com>
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17.0.1_12-jre-alpine
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/code/services/flux-reporting-results/Dockerfile
+++ b/code/services/flux-reporting-results/Dockerfile
@@ -1,11 +1,11 @@
 # See: https://www.baeldung.com/spring-boot-docker-images
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM eclipse-temurin:17.0.1_12-jre-alpine as builder
 MAINTAINER Anthony Kwaje <kwajeanthony@gmail.com>
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17.0.1_12-jre-alpine
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/code/services/flux-types/Dockerfile
+++ b/code/services/flux-types/Dockerfile
@@ -1,11 +1,11 @@
 # See: https://www.baeldung.com/spring-boot-docker-images
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM eclipse-temurin:17.0.1_12-jre-alpine as builder
 MAINTAINER Anthony Kwaje <kwajeanthony@gmail.com>
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17.0.1_12-jre-alpine
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/code/services/fluxes-to-reporting-variables/Dockerfile
+++ b/code/services/fluxes-to-reporting-variables/Dockerfile
@@ -1,11 +1,11 @@
 # See: https://www.baeldung.com/spring-boot-docker-images
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM eclipse-temurin:17.0.1_12-jre-alpine as builder
 MAINTAINER Anthony Kwaje <kwajeanthony@gmail.com>
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17.0.1_12-jre-alpine
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/code/services/land-use-categories/Dockerfile
+++ b/code/services/land-use-categories/Dockerfile
@@ -1,11 +1,11 @@
 # See: https://www.baeldung.com/spring-boot-docker-images
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM eclipse-temurin:17.0.1_12-jre-alpine as builder
 MAINTAINER Anthony Kwaje <kwajeanthony@gmail.com>
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17.0.1_12-jre-alpine
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/code/services/land-uses-flux-types-to-reporting-tables/Dockerfile
+++ b/code/services/land-uses-flux-types-to-reporting-tables/Dockerfile
@@ -1,11 +1,11 @@
 # See: https://www.baeldung.com/spring-boot-docker-images
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM eclipse-temurin:17.0.1_12-jre-alpine as builder
 MAINTAINER Anthony Kwaje <kwajeanthony@gmail.com>
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17.0.1_12-jre-alpine
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/code/services/land-uses-flux-types/Dockerfile
+++ b/code/services/land-uses-flux-types/Dockerfile
@@ -1,11 +1,11 @@
 # See: https://www.baeldung.com/spring-boot-docker-images
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM eclipse-temurin:17.0.1_12-jre-alpine as builder
 MAINTAINER Anthony Kwaje <kwajeanthony@gmail.com>
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17.0.1_12-jre-alpine
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/code/services/locations/Dockerfile
+++ b/code/services/locations/Dockerfile
@@ -1,11 +1,11 @@
 # See: https://www.baeldung.com/spring-boot-docker-images
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM eclipse-temurin:17.0.1_12-jre-alpine as builder
 MAINTAINER Anthony Kwaje <kwajeanthony@gmail.com>
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17.0.1_12-jre-alpine
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/code/services/parties/Dockerfile
+++ b/code/services/parties/Dockerfile
@@ -1,11 +1,11 @@
 # See: https://www.baeldung.com/spring-boot-docker-images
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM eclipse-temurin:17.0.1_12-jre-alpine as builder
 MAINTAINER Anthony Kwaje <kwajeanthony@gmail.com>
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17.0.1_12-jre-alpine
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/code/services/party-types/Dockerfile
+++ b/code/services/party-types/Dockerfile
@@ -1,11 +1,11 @@
 # See: https://www.baeldung.com/spring-boot-docker-images
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM eclipse-temurin:17.0.1_12-jre-alpine as builder
 MAINTAINER Anthony Kwaje <kwajeanthony@gmail.com>
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17.0.1_12-jre-alpine
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/code/services/pools/Dockerfile
+++ b/code/services/pools/Dockerfile
@@ -1,11 +1,11 @@
 # See: https://www.baeldung.com/spring-boot-docker-images
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM eclipse-temurin:17.0.1_12-jre-alpine as builder
 MAINTAINER Anthony Kwaje <kwajeanthony@gmail.com>
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17.0.1_12-jre-alpine
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/code/services/quantity-observations/Dockerfile
+++ b/code/services/quantity-observations/Dockerfile
@@ -1,11 +1,11 @@
 # See: https://www.baeldung.com/spring-boot-docker-images
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM eclipse-temurin:17.0.1_12-jre-alpine as builder
 MAINTAINER Anthony Kwaje <kwajeanthony@gmail.com>
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17.0.1_12-jre-alpine
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/code/services/reporting-frameworks/Dockerfile
+++ b/code/services/reporting-frameworks/Dockerfile
@@ -1,11 +1,11 @@
 # See: https://www.baeldung.com/spring-boot-docker-images
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM eclipse-temurin:17.0.1_12-jre-alpine as builder
 MAINTAINER Anthony Kwaje <kwajeanthony@gmail.com>
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17.0.1_12-jre-alpine
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/code/services/reporting-tables/Dockerfile
+++ b/code/services/reporting-tables/Dockerfile
@@ -1,11 +1,11 @@
 # See: https://www.baeldung.com/spring-boot-docker-images
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM eclipse-temurin:17.0.1_12-jre-alpine as builder
 MAINTAINER Anthony Kwaje <kwajeanthony@gmail.com>
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17.0.1_12-jre-alpine
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/code/services/reporting-variables/Dockerfile
+++ b/code/services/reporting-variables/Dockerfile
@@ -1,11 +1,11 @@
 # See: https://www.baeldung.com/spring-boot-docker-images
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM eclipse-temurin:17.0.1_12-jre-alpine as builder
 MAINTAINER Anthony Kwaje <kwajeanthony@gmail.com>
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17.0.1_12-jre-alpine
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/code/services/task-manager/Dockerfile
+++ b/code/services/task-manager/Dockerfile
@@ -1,11 +1,11 @@
 # See: https://www.baeldung.com/spring-boot-docker-images
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM eclipse-temurin:17.0.1_12-jre-alpine as builder
 MAINTAINER Anthony Kwaje <kwajeanthony@gmail.com>
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17.0.1_12-jre-alpine
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/code/services/tasks/Dockerfile
+++ b/code/services/tasks/Dockerfile
@@ -1,11 +1,11 @@
 # See: https://www.baeldung.com/spring-boot-docker-images
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM eclipse-temurin:17.0.1_12-jre-alpine as builder
 MAINTAINER Anthony Kwaje <kwajeanthony@gmail.com>
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17.0.1_12-jre-alpine
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/code/services/unit-categories/Dockerfile
+++ b/code/services/unit-categories/Dockerfile
@@ -1,11 +1,11 @@
 # See: https://www.baeldung.com/spring-boot-docker-images
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM eclipse-temurin:17.0.1_12-jre-alpine as builder
 MAINTAINER Anthony Kwaje <kwajeanthony@gmail.com>
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17.0.1_12-jre-alpine
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/code/services/units/Dockerfile
+++ b/code/services/units/Dockerfile
@@ -1,11 +1,11 @@
 # See: https://www.baeldung.com/spring-boot-docker-images
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM eclipse-temurin:17.0.1_12-jre-alpine as builder
 MAINTAINER Anthony Kwaje <kwajeanthony@gmail.com>
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17.0.1_12-jre-alpine
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/code/services/vegetation-history-vegetation-types/Dockerfile
+++ b/code/services/vegetation-history-vegetation-types/Dockerfile
@@ -1,11 +1,11 @@
 # See: https://www.baeldung.com/spring-boot-docker-images
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM eclipse-temurin:17.0.1_12-jre-alpine as builder
 MAINTAINER Anthony Kwaje <kwajeanthony@gmail.com>
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17.0.1_12-jre-alpine
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./

--- a/code/services/vegetation-types/Dockerfile
+++ b/code/services/vegetation-types/Dockerfile
@@ -1,11 +1,11 @@
 # See: https://www.baeldung.com/spring-boot-docker-images
-FROM adoptopenjdk:11-jre-hotspot as builder
+FROM eclipse-temurin:17.0.1_12-jre-alpine as builder
 MAINTAINER Anthony Kwaje <kwajeanthony@gmail.com>
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM adoptopenjdk:11-jre-hotspot
+FROM eclipse-temurin:17.0.1_12-jre-alpine
 COPY --from=builder dependencies/ ./
 COPY --from=builder snapshot-dependencies/ ./
 COPY --from=builder spring-boot-loader/ ./


### PR DESCRIPTION
Change the images of the microservices files from `adoptopenjdk:11-jre-hotspot` to `eclipse-temurin:17.0.1_12-jre-alpine` as per the previous image was deprecated [https://hub.docker.com/_/adoptopenjdk](https://hub.docker.com/_/adoptopenjdk ). And the [eclipse-temurin](https://hub.docker.com/_/eclipse-temurin/) image is of less size than the prev existing image. 


Please review it @HarshCasper & @Tonnix. Thanks.
