### PR TITLE
Add CI for building and publishing image on GHCR

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,4 +1,4 @@
-name: Reporting tool frontend
+name: Build Docker Images
 
 on:
   pull_request:
@@ -16,4 +16,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build FLINT Reporting Client
-        run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)
+        run: docker build . --file Dockerfile --tag flint_reporting.client

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,7 +33,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ${{ env.REGISTRY }}/moja-global/flint-reporting-client
+          images: ${{ env.REGISTRY }}/moja-global/flint_reporting.client
 
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -1,37 +1,19 @@
 name: Reporting tool frontend
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
-    branches:
-      - master
-  workflow_dispatch:
-
-defaults:
-  run:
-    shell: bash
-    working-directory: code/client
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [master]
+    
 
 jobs:
-  build:
-    name: Build the frontend
+  # Build FLINT Reporting Tool UI
+  build-flint-reporting-client:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./code/client/
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Setup NodeJS
-        uses: actions/setup-node@v2
-        with:
-          node-version: '14.x'
-
-      - name: Install dependencies
-        run: |
-          npm install -g @angular/cli
-          npm install
-
-      - name: Build UI
-        run: |
-          bash build.sh
+      - uses: actions/checkout@v2
+      - name: Build FLINT Reporting Client
+        run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)

--- a/.github/workflows/frontend-publish.yml
+++ b/.github/workflows/frontend-publish.yml
@@ -1,0 +1,45 @@
+name: Publish FLINT Reporting Tool Client
+
+on:
+  schedule:
+    - cron: '42 22 * * *'
+  push:
+    branches: [ master ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  publish-reporting-tool-frontend:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/moja-global/flint-reporting-client
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: ./code/client/
+          file: "./code/client/Dockerfile"
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Description
Previously the Moja Global docker images were pushed on the docker hub from different people with their accounts. So it's not centralized in one place that's why we have used GitHub Container Registry to maintain all the images in one place. Also, there are no Continuous integration workflows set up in the repository so the images are not able to update when there is a new release in the project. To solve all these problems I have created the CI workflow which will continuously build and publish the image whenever the release triggers it.

-  Added the `frontend-publish.yml` for publishing the docker image on the GitHub container registry using GitHub Actions.

- Added the jobs in `frontend-build.yml` for building the docker image for the Reporting tool frontend.  


